### PR TITLE
use textile threads to store and query memes

### DIFF
--- a/src/utils/Types.ts
+++ b/src/utils/Types.ts
@@ -1,6 +1,7 @@
 import { Buckets, Identity, UserAuth } from '@textile/hub'
 
 export interface MemeMetadata {
+    _id?: string,
     tokenID?: string,    // NFT tokenID
     cid: string,    // IPFS CID
     path: string,   // Bucket path
@@ -29,4 +30,79 @@ export interface AppState {
     www?: string,
     url?: string,
     ipns?: string,
-  }
+}
+
+export const Schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/MemeMetadata",
+    "definitions": {
+        "MemeMetadata": {
+            "type": "object",
+            "title": 'Meme Metadata',
+            "properties": {
+                "_id": {
+                    "type": 'string',
+                    "description": "The instance's id.",
+                },
+                "tokenID": {
+                    "type": "string",
+                    "description": "NFT TokenID."
+                },
+                "cid": {
+                    "type": "string",
+                    "description": "Meme IPFS CID."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Meme bucket path."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the meme."
+                },
+                "txHash": {
+                    "type": "string",
+                    "description": "Blockchain transaction hash."
+                },
+                "date": {
+                    "type": "string",
+                    "description": "The date at which meme is created at."
+                },
+                "likes": {
+                    "type": "number",
+                    "description": "Number of upvotes or likes to this meme."
+                },
+                "dislikes": {
+                    "type": "number",
+                    "description": "Number of downvotes or dislikes to this meme."
+                },
+                "owner": {
+                    "type": "string",
+                    "description": "Address of the meme owner."
+                },
+                "user": {
+                    "type": "string",
+                    "description": "User public key."
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "Tag for this meme.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "price": {
+                    "type": "number",
+                    "description": "Selling price set by the owner."
+                }
+            },
+            "required": [
+                "cid",
+                "path",
+                "name",
+                "date"
+            ],
+            "additionalProperties": false
+        }
+    }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "suppressImplicitAnyIndexErrors": true,
+    "strictPropertyInitialization": false,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
- Use textile threads DB to store and query memes, instead of maintaining a list of index.json file.